### PR TITLE
using dependency graph passed in by blender

### DIFF
--- a/addon/BlenderPartioTools.py
+++ b/addon/BlenderPartioTools.py
@@ -63,9 +63,9 @@ class PartioReader:
 			if totalParticles > 10000:
 				emitterObject.particle_systems[0].settings.display_method = 'DOT'
 
-						
-			degp = bpy.context.evaluated_depsgraph_get()
-			particle_systems = emitterObject.evaluated_get(degp).particle_systems
+			if depsgraph is None:
+				depsgraph = bpy.context.evaluated_depsgraph_get()
+			particle_systems = emitterObject.evaluated_get(depsgraph).particle_systems
 			particles = particle_systems[0].particles
 			
 			posAttr = None


### PR DESCRIPTION
Since Blender 2.81 frame_change_post callbacks receive the dependency graph of the current renderer as parameter. Using this parameter is more reliable than retrieving one using bpy.context.evaluated_depsgraph_get().